### PR TITLE
Fix Uncaught Error

### DIFF
--- a/summernote-ext-checkbox.js
+++ b/summernote-ext-checkbox.js
@@ -24,6 +24,7 @@
                 var button = ui.button({
                     contents: '<i class="glyphicon glyphicon-check"/>',
                     tooltip: 'Checkbox',
+                    container: false,
                     click: function () {
                         context.invoke('insertNode', self.createCheckbox());
                     }


### PR DESCRIPTION
Was getting `Uncaught Error: TOOLTIP: Option "container" provided type "undefined" but expected type "(string|element|boolean)`  when using the plugin. Based on this [thread](https://github.com/summernote/summernote/issues/2740), fixed the issue locally. 